### PR TITLE
shebang environment type

### DIFF
--- a/spotify-lyrics.py
+++ b/spotify-lyrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env/python3
+#!/usr/bin/env python3
 
 """ A Python script that displays the lyrics to the currently playing song on
 Spotify in your terminal.


### PR DESCRIPTION
The first line that sets the python environment should be `#!/usr/bin/env python3` with a space to work properly from usr/bin